### PR TITLE
Feature/series tooltip

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -37,14 +37,13 @@
                    [itemStyle]="series.itemStyle">
   </td-chart-series>
   <!-- td-chart-series-tooltip -->
-  <!-- <td-chart-series-tooltip *ngFor="let tooltip of seriesToolTip; let i=index"
+  <td-chart-series-tooltip *ngFor="let tooltip of seriesToolTip; let i=index"
   [index]="i"
   [textStyle]="tooltip.textStyle"
   [backgroundColor]="tooltip.backgroundColor">
     <ng-template let-params let-ticket="ticket" tdSeriesTooltipFormatter>
       <ng-container *ngIf="params">
         <div layout="row" layout-align="start center">
-          {{i}}
           <mat-icon>
             <span class="tc-blue-300">{{tooltip.icon}}</span>
           </mat-icon>
@@ -54,21 +53,9 @@
         </div>
       </ng-container>
     </ng-template>
-  </td-chart-series-tooltip> -->
-  <td-chart-series-tooltip [config]="seriesToolTip[0]">
-      <ng-template let-params let-ticket="ticket" tdSeriesTooltipFormatter>
-        <ng-container *ngIf="params">
-          <div layout="row" layout-align="start center">
-            <mat-icon>
-              <span class="tc-blue-300">{{seriesToolTip[0].icon}}</span>
-            </mat-icon>
-            <span class="mat-caption pad-left-sm">
-              {{params.seriesName + ': ' + params.value}}
-            </span>
-          </div>
-        </ng-container>
-      </ng-template>
-    </td-chart-series-tooltip>
+  </td-chart-series-tooltip>
+  <!-- <td-chart-series-tooltip [configArray]="seriesToolTip">
+    </td-chart-series-tooltip> -->
 </td-chart>
 <h3>Line Test (atomic)</h3>
 <div layout="row">
@@ -85,11 +72,11 @@
             <span class="tc-blue-300">update_time</span>
           </mat-icon>
           <span class="mat-caption pad-left-sm">
-            {{params[0].seriesName + ': ' + params[0].value[1]}}
+            {{params.seriesName + ': ' + params.value[1]}}
           </span>
         </div>
         <div class="mat-caption">
-          at {{(params[0].name | date:'medium')}}
+          at {{(params.name | date:'medium')}}
         </div>
       </ng-container>
     </ng-template>
@@ -128,21 +115,49 @@
         </ng-container>
       </ng-template>
     </td-chart-series-tooltip>
-    <!-- <td-chart-series-tooltip [config]="seriesToolTip[0]">
-        <ng-template let-params let-ticket="ticket" tdSeriesTooltipFormatter>
-          <ng-container *ngIf="params">
-            <div layout="row" layout-align="start center">
-              <mat-icon>
-                <span class="tc-blue-300">{{seriesToolTip[0].icon}}</span>
-              </mat-icon>
-              <span class="mat-caption pad-left-sm">
-                {{params.seriesName + ': ' + params.value}}
-              </span>
-            </div>
-          </ng-container>
-        </ng-template>
-      </td-chart-series-tooltip> -->
+    <!-- <td-chart-series-tooltip [configArray]="seriesToolTip">
+    </td-chart-series-tooltip> -->
 </td-chart>
+<h3>Line Test - no series (atomic)</h3>
+<td-chart [style.height.px]="300">
+    <td-chart-tooltip [show]="showTooltip" [trigger]="'item'">
+      <ng-template let-params let-ticket="ticket" tdTooltipFormatter>
+        <ng-container *ngIf="params">
+          <div layout="row" layout-align="start center">
+            <mat-icon>
+              <span class="tc-blue-300">update_time</span>
+            </mat-icon>
+            <span class="mat-caption pad-left-sm">
+              {{params.seriesName + ': ' + params.value[1]}}
+            </span>
+          </div>
+          <div class="mat-caption">
+            at {{(params.name | date:'medium')}}
+          </div>
+        </ng-container>
+      </ng-template>
+    </td-chart-tooltip>
+    <td-chart-x-axis [show]="true"
+                      [position]="lineXAxisPositionNoSeries"
+                      [axisLabel]="xAxisLabel"
+                      [type]="'time'"
+                      [boundaryGap]="false"
+                      [axisLine]="xLine"
+                      [splitLine]="splitLine">
+    </td-chart-x-axis>
+    <td-chart-y-axis [show]="true"
+                      [type]="'value'"
+                      [axisLabel]="yAxisLabel"
+                      [axisLine]="yLine"
+                      [splitLine]="splitLine">
+    </td-chart-y-axis>
+    <td-chart-series td-line
+                      *ngFor="let series of linePlotNoSeries"
+                      [data]="series.data"
+                      [name]="series.name"
+                      [lineStyle]="series.lineStyle">
+    </td-chart-series>
+  </td-chart>
 <h3>Line Test (config object)</h3>
 <td-chart [style.height.px]="300"
           [config]="lineConfig">

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -55,7 +55,90 @@
     </ng-template>
   </td-chart-series-tooltip>
   <!-- <td-chart-series-tooltip [configArray]="seriesToolTip">
+      <ng-template let-params let-ticket="ticket" tdSeriesTooltipFormatter>
+          <ng-container *ngIf="params">
+            <div layout="row" layout-align="start center">
+              <mat-icon>
+                <span class="tc-blue-300">{{tooltip.icon}}</span>
+              </mat-icon>
+              <span class="mat-caption pad-left-sm">
+                {{params.seriesName + ': ' + params.value}}
+              </span>
+            </div>
+          </ng-container>
+        </ng-template>
     </td-chart-series-tooltip> -->
+</td-chart>
+<h3>Bar Test Config (atomic)</h3>
+<td-chart [style.height.px]="300"
+                [dataZoom]="false">
+  <td-chart-tooltip [trigger]="'item'">
+    <ng-template let-params let-ticket="ticket" tdTooltipFormatter>
+      <ng-container *ngIf="params">
+        <div layout="row" layout-align="start center">
+          <mat-icon>
+            <span class="tc-blue-300">person</span>
+          </mat-icon>
+          <span class="mat-caption pad-left-sm">
+            {{params.seriesName + ': ' + params.value}}
+          </span>
+        </div>
+      </ng-container>
+    </ng-template>
+  </td-chart-tooltip>
+  <td-chart-x-axis [show]="true"
+                    [position]="'top'"
+                    [type]="'category'"
+                    [boundaryGap]="true"
+                    [axisLine]="xLine"
+                    [splitLine]="{show: false}">
+  </td-chart-x-axis>
+  <td-chart-y-axis [show]="true"
+                    [type]="'value'"
+                    [position]="barYaxisPosition"
+                    [axisLabel]="yAxisLabel"
+                    [axisLine]="yLine"
+                    [max]="120"
+                    [splitLine]="splitLineBar">
+  </td-chart-y-axis>
+  <td-chart-series td-bar
+                   *ngFor="let series of barPlot"
+                   [data]="series.data"
+                   [name]="series.name"
+                   [itemStyle]="series.itemStyle">
+  </td-chart-series>
+  <!-- td-chart-series-tooltip -->
+  <!-- <td-chart-series-tooltip *ngFor="let tooltip of seriesToolTip; let i=index"
+  [index]="i"
+  [textStyle]="tooltip.textStyle"
+  [backgroundColor]="tooltip.backgroundColor">
+    <ng-template let-params let-ticket="ticket" tdSeriesTooltipFormatter>
+      <ng-container *ngIf="params">
+        <div layout="row" layout-align="start center">
+          <mat-icon>
+            <span class="tc-blue-300">{{tooltip.icon}}</span>
+          </mat-icon>
+          <span class="mat-caption pad-left-sm">
+            {{params.seriesName + ': ' + params.value}}
+          </span>
+        </div>
+      </ng-container>
+    </ng-template>
+  </td-chart-series-tooltip> -->
+  <td-chart-series-tooltip [configArray]="seriesToolTip">
+      <ng-template let-params let-ticket="ticket" let-item="item" tdSeriesTooltipFormatter>
+          <ng-container *ngIf="params">
+            <div layout="row" layout-align="start center">
+              <mat-icon>
+                <span class="tc-blue-300">{{seriesToolTip[params.seriesIndex].icon}}</span>
+              </mat-icon>
+              <span class="mat-caption pad-left-sm">
+                {{params.seriesName + ': ' + params.value}}
+              </span>
+            </div>
+          </ng-container>
+        </ng-template>
+    </td-chart-series-tooltip>
 </td-chart>
 <h3>Line Test (atomic)</h3>
 <div layout="row">

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -130,7 +130,7 @@
           <ng-container *ngIf="params">
             <div layout="row" layout-align="start center">
               <mat-icon>
-                <span class="tc-blue-300">{{seriesToolTip[params.seriesIndex].icon}}</span>
+                <span class="tc-blue-300">{{seriesToolTip[params?.seriesIndex]?.icon}}</span>
               </mat-icon>
               <span class="mat-caption pad-left-sm">
                 {{params.seriesName + ': ' + params.value}}

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -36,6 +36,35 @@
                    [name]="series.name"
                    [itemStyle]="series.itemStyle">
   </td-chart-series>
+  <!-- td-chart-series-tooltip -->
+  <!-- <td-chart-series-tooltip *ngFor="let tooltip of seriesToolTip; let i=index" [index]="i" [textStyle]="tooltip.textStyle">
+    <ng-template let-params let-ticket="ticket" tdSeriesTooltipFormatter>
+      <ng-container *ngIf="params">
+        <div layout="row" layout-align="start center">
+          <mat-icon>
+            <span class="tc-blue-300">{{tooltip.icon}}</span>
+          </mat-icon>
+          <span class="mat-caption pad-left-sm">
+            {{params.seriesName + ': ' + params.value}}
+          </span>
+        </div>
+      </ng-container>
+    </ng-template>
+  </td-chart-series-tooltip> -->
+    <td-chart-series-tooltip [configArray]="seriesToolTip">
+    <ng-template let-params let-ticket="ticket" tdSeriesTooltipFormatter>
+      <ng-container *ngIf="params">
+        <div layout="row" layout-align="start center">
+          <mat-icon>
+            <span class="tc-blue-300"> test {{seriesToolTip[1].icon}}</span>
+          </mat-icon>
+          <span class="mat-caption pad-left-sm">
+            {{params.seriesName + ': ' + params.value}}
+          </span>
+        </div>
+      </ng-container>
+    </ng-template>
+  </td-chart-series-tooltip>
 </td-chart>
 <h3>Line Test (atomic)</h3>
 <div layout="row">
@@ -86,3 +115,8 @@
 <td-chart [style.height.px]="300"
           [config]="lineConfig">
 </td-chart>
+
+<ng-template #tooltipContent
+            [ngTemplateOutlet]="formatterTemplate"
+            [ngTemplateOutletContext]="_context">
+</ng-template>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -37,10 +37,14 @@
                    [itemStyle]="series.itemStyle">
   </td-chart-series>
   <!-- td-chart-series-tooltip -->
-  <!-- <td-chart-series-tooltip *ngFor="let tooltip of seriesToolTip; let i=index" [index]="i" [textStyle]="tooltip.textStyle">
+  <!-- <td-chart-series-tooltip *ngFor="let tooltip of seriesToolTip; let i=index"
+  [index]="i"
+  [textStyle]="tooltip.textStyle"
+  [backgroundColor]="tooltip.backgroundColor">
     <ng-template let-params let-ticket="ticket" tdSeriesTooltipFormatter>
       <ng-container *ngIf="params">
         <div layout="row" layout-align="start center">
+          {{i}}
           <mat-icon>
             <span class="tc-blue-300">{{tooltip.icon}}</span>
           </mat-icon>
@@ -51,20 +55,20 @@
       </ng-container>
     </ng-template>
   </td-chart-series-tooltip> -->
-    <td-chart-series-tooltip [configArray]="seriesToolTip">
-    <ng-template let-params let-ticket="ticket" tdSeriesTooltipFormatter>
-      <ng-container *ngIf="params">
-        <div layout="row" layout-align="start center">
-          <mat-icon>
-            <span class="tc-blue-300"> test {{seriesToolTip[1].icon}}</span>
-          </mat-icon>
-          <span class="mat-caption pad-left-sm">
-            {{params.seriesName + ': ' + params.value}}
-          </span>
-        </div>
-      </ng-container>
-    </ng-template>
-  </td-chart-series-tooltip>
+  <td-chart-series-tooltip [config]="seriesToolTip[0]">
+      <ng-template let-params let-ticket="ticket" tdSeriesTooltipFormatter>
+        <ng-container *ngIf="params">
+          <div layout="row" layout-align="start center">
+            <mat-icon>
+              <span class="tc-blue-300">{{seriesToolTip[0].icon}}</span>
+            </mat-icon>
+            <span class="mat-caption pad-left-sm">
+              {{params.seriesName + ': ' + params.value}}
+            </span>
+          </div>
+        </ng-container>
+      </ng-template>
+    </td-chart-series-tooltip>
 </td-chart>
 <h3>Line Test (atomic)</h3>
 <div layout="row">
@@ -72,8 +76,8 @@
     Show/Hide Tooltip
   </button>
 </div>
-<td-chart [style.height.px]="300" [config]="{series: linePlot}">
-  <td-chart-tooltip [show]="showTooltip">
+<td-chart [style.height.px]="300">
+  <td-chart-tooltip [show]="showTooltip" [trigger]="'item'">
     <ng-template let-params let-ticket="ticket" tdTooltipFormatter>
       <ng-container *ngIf="params">
         <div layout="row" layout-align="start center">
@@ -110,13 +114,36 @@
                     [name]="series.name"
                     [lineStyle]="series.lineStyle">
   </td-chart-series>
+  <td-chart-series-tooltip *ngFor="let tooltip of seriesToolTip; let i=index" [index]="i" [textStyle]="tooltip.textStyle" [backgroundColor]="tooltip.backgroundColor">
+      <ng-template let-params let-ticket="ticket" tdSeriesTooltipFormatter>
+        <ng-container *ngIf="params">
+          <div layout="row" layout-align="start center">
+            <mat-icon>
+              <span class="tc-blue-300">{{tooltip.icon}}</span>
+            </mat-icon>
+            <span class="mat-caption pad-left-sm">
+              {{params.seriesName + ': ' + params.value}}
+            </span>
+          </div>
+        </ng-container>
+      </ng-template>
+    </td-chart-series-tooltip>
+    <!-- <td-chart-series-tooltip [config]="seriesToolTip[0]">
+        <ng-template let-params let-ticket="ticket" tdSeriesTooltipFormatter>
+          <ng-container *ngIf="params">
+            <div layout="row" layout-align="start center">
+              <mat-icon>
+                <span class="tc-blue-300">{{seriesToolTip[0].icon}}</span>
+              </mat-icon>
+              <span class="mat-caption pad-left-sm">
+                {{params.seriesName + ': ' + params.value}}
+              </span>
+            </div>
+          </ng-container>
+        </ng-template>
+      </td-chart-series-tooltip> -->
 </td-chart>
 <h3>Line Test (config object)</h3>
 <td-chart [style.height.px]="300"
           [config]="lineConfig">
 </td-chart>
-
-<ng-template #tooltipContent
-            [ngTemplateOutlet]="formatterTemplate"
-            [ngTemplateOutletContext]="_context">
-</ng-template>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -77,14 +77,14 @@ export class DocsAppComponent {
         color: '#818181',
       },
       backgroundColor: '#fff',
-      formatter: ' inline Label {a}: {c0}',
+      // formatter: ' inline Label {a}: {c0}',
     },
         {
       icon: 'dashboard',
       textStyle: {
         color: '#00efff',
       },
-      formatter: 'test {a}: {c0}',
+      // formatter: 'test {a}: {c0}',
     },
   ];
 
@@ -150,6 +150,30 @@ export class DocsAppComponent {
     }],
   }];
 
+  linePlotNoSeries: any[] = [{
+    name: 'Line Test',
+    type: 'line',
+    lineStyle: {
+      color: '#575757',
+      width: 2,
+      shadowBlur: 5,
+      shadowColor: 'rgba(0, 0, 0, 0.15)',
+      shadowOffsetX: 0,
+      shadowOffsetY: 5,
+      opacity: 0.75,
+    },
+    data: [{
+      name: NOW.toISOString(),
+      value: [NOW.toISOString(), 200],
+    }, {
+      name: new Date(NOW.getTime() + (24 * 3600 * 1000)).toISOString(),
+      value: [new Date(NOW.getTime() + (24 * 3600 * 1000)).toISOString(), 50],
+    }, {
+      name: new Date(NOW.getTime() + (2 * 24 * 3600 * 1000)).toISOString(),
+      value: [new Date(NOW.getTime() + (2 * 24 * 3600 * 1000)).toISOString(), 100],
+    }],
+  }];
+
   lineConfig: any = {
     xAxis: [{show: true, type: 'time', boundaryGap: false, axisLine: {show: false}, splitLine: {show: false}}],
     yAxis: [{show: true, type: 'value', axisLabel: {inside: true}}],
@@ -163,6 +187,7 @@ export class DocsAppComponent {
   
   barYaxisPosition: TdYAxisPosition = TdYAxisPosition.Right;
   lineXAxisPosition: TdXAxisPosition = TdXAxisPosition.Top;
+  lineXAxisPositionNoSeries: TdXAxisPosition = TdXAxisPosition.Bottom;
 
   constructor(private _changeDetectorRef: ChangeDetectorRef) {
   }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -30,40 +30,6 @@ export class DocsAppComponent {
   }];
 
   showTooltip: boolean = true;
-  linePlot: any[] = [{
-    name: 'Line Test',
-    type: 'line',
-    lineStyle: {
-      color: '#575757',
-      width: 2,
-      shadowBlur: 5,
-      shadowColor: 'rgba(0, 0, 0, 0.15)',
-      shadowOffsetX: 0,
-      shadowOffsetY: 5,
-      opacity: 0.75,
-    },
-    data: [{
-      name: NOW.toISOString(),
-      value: [NOW.toISOString(), 200],
-    }, {
-      name: new Date(NOW.getTime() + (24 * 3600 * 1000)).toISOString(),
-      value: [new Date(NOW.getTime() + (24 * 3600 * 1000)).toISOString(), 50],
-    }, {
-      name: new Date(NOW.getTime() + (2 * 24 * 3600 * 1000)).toISOString(),
-      value: [new Date(NOW.getTime() + (2 * 24 * 3600 * 1000)).toISOString(), 100],
-    }],
-  }];
-
-  lineConfig: any = {
-    xAxis: [{show: true, type: 'time', boundaryGap: false, axisLine: {show: false}, splitLine: {show: false}}],
-    yAxis: [{show: true, type: 'value', axisLabel: {inside: true}}],
-    series: this.linePlot,
-    tooltip: {
-      show: true,
-      trigger: 'axis',
-      showContent: true,
-    },
-  };
 
   yLine: IAxisLine = { 
     show: true, 
@@ -111,17 +77,90 @@ export class DocsAppComponent {
         color: '#818181',
       },
       backgroundColor: '#fff',
-      formatter: '{a}: {c0}',
+      formatter: ' inline Label {a}: {c0}',
     },
         {
       icon: 'dashboard',
       textStyle: {
         color: '#00efff',
       },
-      formatter: '{a}: {c0}',
+      formatter: 'test {a}: {c0}',
     },
   ];
 
+  seriesLineToolTip: any[] = [
+    {
+      textStyle: {
+        color: '#818181',
+      },
+      backgroundColor: '#fff',
+      // formatter: ' inline Label {a}: {c0}',
+    },
+        {
+      textStyle: {
+        color: '#00efff',
+      },
+      // formatter: 'test {a}: {c0}',
+    },
+  ];
+
+  linePlot: any[] = [{
+    name: 'Line Test',
+    type: 'line',
+    lineStyle: {
+      color: '#575757',
+      width: 2,
+      shadowBlur: 5,
+      shadowColor: 'rgba(0, 0, 0, 0.15)',
+      shadowOffsetX: 0,
+      shadowOffsetY: 5,
+      opacity: 0.75,
+    },
+    data: [{
+      name: NOW.toISOString(),
+      value: [NOW.toISOString(), 200],
+    }, {
+      name: new Date(NOW.getTime() + (24 * 3600 * 1000)).toISOString(),
+      value: [new Date(NOW.getTime() + (24 * 3600 * 1000)).toISOString(), 50],
+    }, {
+      name: new Date(NOW.getTime() + (2 * 24 * 3600 * 1000)).toISOString(),
+      value: [new Date(NOW.getTime() + (2 * 24 * 3600 * 1000)).toISOString(), 100],
+    }],
+  }, {
+    name: 'Line Test',
+    type: 'line',
+    lineStyle: {
+      color: 'red',
+      width: 2,
+      shadowBlur: 5,
+      shadowColor: 'rgba(0, 0, 0, 0.15)',
+      shadowOffsetX: 0,
+      shadowOffsetY: 5,
+      opacity: 0.75,
+    },
+    data: [{
+      name: NOW.toISOString(),
+      value: [NOW.toISOString(), 200],
+    }, {
+      name: new Date(NOW.getTime() + (10 * 3600 * 1000)).toISOString(),
+      value: [new Date(NOW.getTime() + (10 * 3600 * 1000)).toISOString(), 50],
+    }, {
+      name: new Date(NOW.getTime() + (3 * 24 * 3600 * 1000)).toISOString(),
+      value: [new Date(NOW.getTime() + (3 * 24 * 3600 * 1000)).toISOString(), 100],
+    }],
+  }];
+
+  lineConfig: any = {
+    xAxis: [{show: true, type: 'time', boundaryGap: false, axisLine: {show: false}, splitLine: {show: false}}],
+    yAxis: [{show: true, type: 'value', axisLabel: {inside: true}}],
+    series: this.linePlot,
+    tooltip: {
+      show: true,
+      trigger: 'item',
+      showContent: true,
+    },
+  };
+  
   barYaxisPosition: TdYAxisPosition = TdYAxisPosition.Right;
   lineXAxisPosition: TdXAxisPosition = TdXAxisPosition.Top;
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -84,7 +84,7 @@ export class DocsAppComponent {
       textStyle: {
         color: '#00efff',
       },
-      // formatter: 'test {a}: {c0}',
+      // formatter: 'inline Label {a}: {c0}',
     },
   ];
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -104,6 +104,24 @@ export class DocsAppComponent {
     },
   };
 
+  seriesToolTip: any[] = [
+    {
+      icon: 'person',
+      textStyle: {
+        color: '#818181',
+      },
+      backgroundColor: '#fff',
+      formatter: '{a}: {c0}',
+    },
+        {
+      icon: 'dashboard',
+      textStyle: {
+        color: '#00efff',
+      },
+      formatter: '{a}: {c0}',
+    },
+  ];
+
   barYaxisPosition: TdYAxisPosition = TdYAxisPosition.Right;
   lineXAxisPosition: TdXAxisPosition = TdXAxisPosition.Top;
 

--- a/src/platform/echarts/base/base.module.ts
+++ b/src/platform/echarts/base/base.module.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 
 import { TdChartComponent } from './chart.component';
 import { TdChartTooltipComponent, TdChartTooltipFormatterDirective } from './tooltip/tooltip.component';
+import { TdSeriesTooltipComponent, TdChartSeriesTooltipFormatterDirective } from './tooltip/series-tooltip.component';
 import { TdChartXAxisComponent } from './axis/x-axis.component';
 import { TdChartYAxisComponent } from './axis/y-axis.component';
 
@@ -12,6 +13,8 @@ export const BASE_MODULE_COMPONENTS: Type<any>[] = [
   TdChartTooltipFormatterDirective,
   TdChartXAxisComponent,
   TdChartYAxisComponent,
+  TdSeriesTooltipComponent,
+  TdChartSeriesTooltipFormatterDirective,
 ];
 
 @NgModule({

--- a/src/platform/echarts/base/chart.service.ts
+++ b/src/platform/echarts/base/chart.service.ts
@@ -56,21 +56,6 @@ export class TdChartOptionsService {
   }
 
   /**
-   * Sets Series option
-   *
-   * @param option Series option (e.i. tooltip)
-   * @param value Array of values for series option
-   */
-  setSeriesOptionArray(option: string, value: any[]): void {
-    const seriesOption: any = { [option]: value };
-    if (seriesOption[option]) {
-      seriesOption[option].forEach((prevValue: any, i: number) => {
-        this.setSeriesOption(option, prevValue, i);
-      });
-    }
-  }
-
-  /**
    * Sets Series option using an index, normally used with an ngFor in the template
    *
    * @param option Series option (e.i. tooltip)

--- a/src/platform/echarts/base/chart.service.ts
+++ b/src/platform/echarts/base/chart.service.ts
@@ -35,8 +35,14 @@ export class TdChartOptionsService {
     return this._options[option];
   }
 
+  /**
+   * Sets Series option using an index, normally used with an ngFor in the template or with setSeriesOptionArray method
+   *
+   * @param option Series option (e.i. tooltip)
+   * @param value series option value(s)
+   * @param index Series Index used to specify where the value param to be added
+   */
   setSeriesOption(option: string, value: any, index: number): void {
-
     const seriesOption: any = {[option]: value};
     setTimeout(() => {
       const prevSeriesValue: any[] = this.getOption('series');
@@ -49,15 +55,26 @@ export class TdChartOptionsService {
     });
   }
 
-  setSeriesOptionAll(option: string, value: any): void {
-    setTimeout(() => {
-    const prevSeriesValue: any[] = this.getOption('series');
-    prevSeriesValue.forEach((val: any, i: number) => {
-      this.setSeriesOption(option, value, i);
-    });
-  });
+  /**
+   * Sets Series option
+   *
+   * @param option Series option (e.i. tooltip)
+   * @param value Array of values for series option
+   */
+  setSeriesOptionArray(option: string, value: any[]): void {
+    const seriesOption: any = { [option]: value };
+    if (seriesOption[option]) {
+      seriesOption[option].forEach((prevValue: any, i: number) => {
+        this.setSeriesOption(option, prevValue, i);
+      });
+    }
   }
 
+  /**
+   * Sets Series option using an index, normally used with an ngFor in the template
+   *
+   * @param option Series option (e.i. tooltip)
+   */
   clearSeriesOption(option: string): void {
     const prevSeriesValue: any[] = this.getOption('series');
     prevSeriesValue.forEach((val: any, i: number) => {

--- a/src/platform/echarts/base/chart.service.ts
+++ b/src/platform/echarts/base/chart.service.ts
@@ -36,6 +36,7 @@ export class TdChartOptionsService {
   }
 
   setSeriesOption(option: string, value: any, index: number): void {
+
     const seriesOption: any = {[option]: value};
     setTimeout(() => {
       const prevSeriesValue: any[] = this.getOption('series');
@@ -48,13 +49,13 @@ export class TdChartOptionsService {
     });
   }
 
-  setSeriesOptionArray(option: string, value: any[]): void {
-    const seriesOption: any = { [option]: value };
-    if (seriesOption[option]) {
-      seriesOption[option].forEach((prevValue: any, i: number) => {
-        this.setSeriesOption(option, prevValue, i);
-      });
-    }
+  setSeriesOptionAll(option: string, value: any): void {
+    setTimeout(() => {
+    const prevSeriesValue: any[] = this.getOption('series');
+    prevSeriesValue.forEach((val: any, i: number) => {
+      this.setSeriesOption(option, value, i);
+    });
+  });
   }
 
   clearSeriesOption(option: string): void {

--- a/src/platform/echarts/base/chart.service.ts
+++ b/src/platform/echarts/base/chart.service.ts
@@ -35,8 +35,38 @@ export class TdChartOptionsService {
     return this._options[option];
   }
 
+  setSeriesOption(option: string, value: any, index: number): void {
+    const seriesOption: any = {[option]: value};
+    setTimeout(() => {
+      const prevSeriesValue: any[] = this.getOption('series');
+      if (prevSeriesValue[index]) {
+        prevSeriesValue[index] = {...prevSeriesValue[index], ...seriesOption};
+        this.setOption('series', prevSeriesValue);
+      } else {
+        this.setOption('series', seriesOption);
+      }
+    });
+  }
+
+  setSeriesOptionArray(option: string, value: any[]): void {
+    const seriesOption: any = { [option]: value };
+    if (seriesOption[option]) {
+      seriesOption[option].forEach((prevValue: any, i: number) => {
+        this.setSeriesOption(option, prevValue, i);
+      });
+    }
+  }
+
+  clearSeriesOption(option: string): void {
+    const prevSeriesValue: any[] = this.getOption('series');
+    prevSeriesValue.forEach((val: any, i: number) => {
+      this.setSeriesOption(option, undefined, i);
+    });
+  }
+  
   clearOption(option: string): void {
     this.setOption(option, undefined);
+
   }
 
   listen(): Observable<any> {

--- a/src/platform/echarts/base/tooltip/series-tooltip.component.html
+++ b/src/platform/echarts/base/tooltip/series-tooltip.component.html
@@ -1,3 +1,4 @@
+
 <ng-template #tooltipContent
             [ngTemplateOutlet]="formatterTemplate"
             [ngTemplateOutletContext]="_context">

--- a/src/platform/echarts/base/tooltip/series-tooltip.component.html
+++ b/src/platform/echarts/base/tooltip/series-tooltip.component.html
@@ -1,0 +1,4 @@
+<ng-template #tooltipContent
+            [ngTemplateOutlet]="formatterTemplate"
+            [ngTemplateOutletContext]="_context">
+</ng-template>

--- a/src/platform/echarts/base/tooltip/series-tooltip.component.html
+++ b/src/platform/echarts/base/tooltip/series-tooltip.component.html
@@ -1,4 +1,3 @@
-
 <ng-template #tooltipContent
             [ngTemplateOutlet]="formatterTemplate"
             [ngTemplateOutletContext]="_context">

--- a/src/platform/echarts/base/tooltip/series-tooltip.component.ts
+++ b/src/platform/echarts/base/tooltip/series-tooltip.component.ts
@@ -43,7 +43,7 @@ export class TdSeriesTooltipComponent implements OnChanges, OnInit, OnDestroy {
   @Input('config') config: any;
   @Input('configArray') configArray: any[];
   @Input('index') index: number = 0;
-
+  @Input('formatter') formatter: any;
   // Parent tooltip trigger must be set to 'item' to render these properties
   @Input('position') position: string | string[] | number[];
   @Input('backgroundColor') backgroundColor: string = 'rgba(50,50,50,0.7)';
@@ -86,7 +86,7 @@ export class TdSeriesTooltipComponent implements OnChanges, OnInit, OnDestroy {
         padding: this.padding,
         textStyle: this.textStyle,
         extraCssText: this.extraCssText,
-        formatter: this._formatter(),
+        formatter: this.formatter ? this.formatter : this._formatter(),
       });
       // set series tooltip configuration in parent chart and render new configurations
       this._optionsService.setSeriesOption('tooltip', config, this.index);
@@ -95,13 +95,17 @@ export class TdSeriesTooltipComponent implements OnChanges, OnInit, OnDestroy {
       }
   }
   /**
-   * Open tfor discussion, might be overkill but wanted to include it in case we want to provide
-   * a global series config. Bypasses setSeriesOption and ngTemplateOutlet. 
-   * Falls back to parent tooltip properties
+   * processes configArray and updates
    *
    */
   private _setConfig(): void {
-    this._optionsService.setSeriesOptionArray('tooltip', this.configArray);
+    let config: any = assignDefined(this._state, this.configArray);
+    for (const key of Object.keys(config)) {
+      if (!config[key].formatter) {
+        config[key].formatter = this._formatter();
+      }
+      this._optionsService.setSeriesOption('tooltip', config[key], parseInt(key, 0));
+    }
   }
   
   /**

--- a/src/platform/echarts/base/tooltip/series-tooltip.component.ts
+++ b/src/platform/echarts/base/tooltip/series-tooltip.component.ts
@@ -1,0 +1,123 @@
+import { 
+  Component,
+  OnInit,
+  Input,
+  ContentChild,
+  ViewChild,
+  TemplateRef,
+  ChangeDetectorRef,
+  ElementRef,
+  ChangeDetectionStrategy,
+  Directive,
+  OnChanges,
+  OnDestroy, 
+} 
+  from '@angular/core';
+
+import { TdChartOptionsService } from '../chart.service';
+import { assignDefined } from '../utils';
+
+interface ITdSeriesTooltip {
+  
+  position?: any;
+  formatter?: any;
+  backgroundColor?: any;
+  borderColor?: any;
+  borderWidth?: number;
+  padding?: number;
+  textStyle?: any;
+  extraCssText?: string;
+}
+
+export class TdTooltipContext {
+  $implicit: any;
+  ticket: string;
+}
+
+@Directive({
+  selector: 'ng-template[tdSeriesTooltipFormatter]',
+})
+export class TdChartSeriesTooltipFormatterDirective {
+}
+
+@Component({
+  selector: 'td-chart-series-tooltip',
+  templateUrl: './series-tooltip.component.html',
+  styleUrls: ['./series-tooltip.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class TdSeriesTooltipComponent implements OnChanges, OnInit, OnDestroy {
+
+  private _state: any = {};
+
+  _context: TdTooltipContext = new TdTooltipContext();
+
+  @Input('config') config: ITdSeriesTooltip = {};
+  @Input('configArray') configArray: ITdSeriesTooltip[] = [];
+  @Input('index') index: number = 0;
+  @Input('position') position: string | string[] | number[];
+  @Input('backgroundColor') backgroundColor: string = 'rgba(50,50,50,0.7)';
+  @Input('borderColor') borderColor: string = '#333';
+  @Input('borderWidth') borderWidth: number = 0;
+  @Input('padding') padding: number = 5;
+  @Input('textStyle') textStyle: any = {
+    color: '#FFF',
+  };
+  @Input('extraCssText') extraCssText: string;
+
+  @ContentChild(TdChartSeriesTooltipFormatterDirective, {read: TemplateRef}) formatterTemplate: TemplateRef<any>;
+  @ViewChild('tooltipContent') fullTemplate: TemplateRef<any>;
+
+  constructor(private _changeDetectorRef: ChangeDetectorRef,
+              private _elementRef: ElementRef,
+              private _optionsService: TdChartOptionsService) {
+  }
+
+  ngOnInit(): void {
+    this._setOptions();
+  }
+
+  ngOnChanges(): void {
+    this._setOptions();
+  }
+
+  ngOnDestroy(): void {
+    this._removeOption();
+  }
+
+  private _setOptions(): void {
+    let config: any = assignDefined(this._state, this.config ? this.config : {}, {
+      position: this.position,
+      formatter: (params: any, ticket: any, callback: (ticket: string, html: string) => void) => {
+        this._context = {
+          $implicit: params,
+          ticket: ticket,
+        };
+        // timeout set since we need to set the HTML at the end of the angular lifecycle when
+        // the tooltip delay is more than 0
+        setTimeout(() => {
+          callback(ticket, (<HTMLElement>this._elementRef.nativeElement).innerHTML);
+        });
+        this._changeDetectorRef.markForCheck();
+        return (<HTMLElement>this._elementRef.nativeElement).innerHTML;
+      },
+      backgroundColor: this.backgroundColor,
+      borderColor: this.borderColor,
+      borderWidth: this.borderWidth,
+      padding: this.padding,
+      textStyle: this.textStyle,
+      extraCssText: this.extraCssText,
+    });
+    // set series tooltip configuration in parent chart and render new configurations
+    if (this.configArray.length >= 1) {
+      this._optionsService.setSeriesOptionArray('tooltip', this.configArray);
+    } else {
+      this._optionsService.setSeriesOption('tooltip', config, this.index);
+    }
+  }
+
+  private _removeOption(): void {
+    this._optionsService.clearSeriesOption('tooltip');
+  }
+
+}

--- a/src/platform/echarts/base/tooltip/series-tooltip.component.ts
+++ b/src/platform/echarts/base/tooltip/series-tooltip.component.ts
@@ -53,6 +53,8 @@ export class TdSeriesTooltipComponent implements OnChanges, OnInit, OnDestroy {
 
   @Input('config') config: any = {};
   @Input('index') index: number = 0;
+
+  // Parent tooltip trigger must be set to 'item' to render these properties
   @Input('position') position: string | string[] | number[];
   @Input('backgroundColor') backgroundColor: string = 'rgba(50,50,50,0.7)';
   @Input('borderColor') borderColor: string = '#333';
@@ -96,7 +98,6 @@ export class TdSeriesTooltipComponent implements OnChanges, OnInit, OnDestroy {
         formatter: this.formatter(),
       });
       // set series tooltip configuration in parent chart and render new configurations
-
       if (checkKeys) {
         this._optionsService.setSeriesOption('tooltip', config, this.index);
       } else {

--- a/src/platform/echarts/base/utils/assign-defined.ts
+++ b/src/platform/echarts/base/utils/assign-defined.ts
@@ -1,5 +1,4 @@
 export function assignDefined(target: any, ...sources: any[]): any {
-
   for (const key of Object.keys(target)) {
     delete target[key];
   }

--- a/src/platform/echarts/base/utils/assign-defined.ts
+++ b/src/platform/echarts/base/utils/assign-defined.ts
@@ -1,4 +1,5 @@
 export function assignDefined(target: any, ...sources: any[]): any {
+
   for (const key of Object.keys(target)) {
     delete target[key];
   }


### PR DESCRIPTION
## Description
Added Series tooltip component - includes a config version and a ngFor to target content and styles for specific series tooltip. **Note: parent tooltip tigger property must equal 'item'.** otherwise the series tooltip will be ignored at least at least on bar and line so far.

### What's included?
<!-- List features included in this PR -->
Modified to test series tooltips
- src/app/app.component.html
- src/app/app.component.ts

Added series tooltip component and directive
- src/platform/echarts/base/base.module.ts
- src/platform/echarts/base/tooltip/series-tooltip.component.html
- src/platform/echarts/base/tooltip/series-tooltip.component.ts
- src/platform/echarts/base/tooltip/series-tooltip.component.scss

Updated chart service to include series option updates and a method to update series options via configArray property. uses strings only (currently does support injecting angular components).
-  src/platform/echarts/base/chart.service.ts

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `npm run serve`
- [ ] then this
- [ ] finally this

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker
