### PR TITLE
fix(tooltip): set formatter only if template has been provided

### DIFF
--- a/src/platform/echarts/tooltip/series-tooltip.component.ts
+++ b/src/platform/echarts/tooltip/series-tooltip.component.ts
@@ -65,7 +65,7 @@ export class TdSeriesTooltipComponent implements OnChanges, OnDestroy {
       padding: this.padding,
       textStyle: this.textStyle,
       extraCssText: this.extraCssText,
-      formatter: this.formatter ? this.formatter : this._formatter(),
+      formatter: this.formatter ? this.formatter : (this.formatterTemplate ? this._formatter() : undefined),
     });
     // set series tooltip configuration in parent chart and render new configurations
     this._seriesComponent.setStateOption('tooltip', config);

--- a/src/platform/echarts/tooltip/tooltip.component.ts
+++ b/src/platform/echarts/tooltip/tooltip.component.ts
@@ -97,7 +97,7 @@ export class TdChartTooltipComponent implements OnChanges, OnDestroy {
       confine: this.confine,
       transitionDuration: this.transitionDuration,
       position: this.position,
-      formatter: this.formatter ? this.formatter : this._formatter(),
+      formatter: this.formatter ? this.formatter : (this.formatterTemplate ? this._formatter() : undefined),
       backgroundColor: this.backgroundColor,
       borderColor: this.borderColor,
       borderWidth: this.borderWidth,


### PR DESCRIPTION
### What's included?
<!-- List features included in this PR -->
- Make sure formatter is only set if template has been provided, else we show default tooltip.

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.
