### PR TITLE
removed this._instance.clear() from ngOnChanges

### DIFF
--- a/src/platform/echarts/base/chart.component.ts
+++ b/src/platform/echarts/base/chart.component.ts
@@ -116,7 +116,6 @@ export class TdChartComponent implements AfterViewInit, OnChanges, OnDestroy {
 
   ngOnChanges(): void {
     if (this._instance) {
-      this._instance.clear();
       this.render();
     }
   }


### PR DESCRIPTION
## Description/What's included?
Simply removed this._instance.clear() from `TdChartComponent` `this._instance` was already exposed through a getter.  Tested the ability access `_instance` via ViewChild for both atomic and config in `TypesBarComponent` and all looks good. No example provided but figured that is documentation item and perhaps a stackBlitz if we wanted to show examples of using the instance hook. closes https://github.com/Teradata/covalent-echarts/issues/39

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `npm run serve`
- [ ] then this
- [ ] finally this

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker
