### PR TITLE
feat(chart): add themeName and renderer inputs to set theme and render mode

### DIFF
--- a/src/app/components/chart/chart.component.html
+++ b/src/app/components/chart/chart.component.html
@@ -1,0 +1,1 @@
+<td-readme-loader resourceUrl="platform/echarts/base/README.md"></td-readme-loader>

--- a/src/app/components/chart/chart.component.ts
+++ b/src/app/components/chart/chart.component.ts
@@ -1,0 +1,15 @@
+import {
+  Component,
+  ChangeDetectionStrategy,
+} from '@angular/core';
+
+@Component({
+  selector: 'chart',
+  templateUrl: './chart.component.html',
+  styleUrls: ['./chart.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  preserveWhitespaces: true,
+})
+export class ChartComponent {
+
+}

--- a/src/app/components/components.component.html
+++ b/src/app/components/components.component.html
@@ -37,6 +37,16 @@
                     matTooltipPosition="after">chrome_reader_mode</mat-icon>
           <span *ngIf="!miniNav">Getting Started</span>
         </a>
+        <a mat-list-item
+            color="accent"
+            [routerLinkActiveOptions]="{exact:true}"
+            [routerLink]="['/components', 'chart']"
+            routerLinkActive="active">
+          <mat-icon matListIcon
+                    [matTooltip]="miniNav ? 'Chart' : ''"
+                    matTooltipPosition="after">satellite</mat-icon>
+          <span *ngIf="!miniNav">Chart</span>
+        </a>
         <mat-divider></mat-divider>
         <h3 matSubheader>
           <span *ngIf="!miniNav">Charts</span>

--- a/src/app/components/components.module.ts
+++ b/src/app/components/components.module.ts
@@ -26,6 +26,7 @@ import { ToolbarModule } from '../toolbar/toolbar.module';
 import { ComponentsComponent } from './components.component';
 import { OverviewComponent } from './overview/overview.component';
 import { GettingStartedComponent } from './getting-started/getting-started.component';
+import { ChartComponent } from './chart/chart.component';
 
 import { DocumentationToolsModule } from '../documentation-tools';
 
@@ -62,6 +63,7 @@ import { moduleRoutes } from './components.routes';
     ComponentsComponent,
     OverviewComponent,
     GettingStartedComponent,
+    ChartComponent,
   ],
 })
 export class ComponentsModule {}

--- a/src/app/components/components.routes.ts
+++ b/src/app/components/components.routes.ts
@@ -2,6 +2,7 @@ import { Routes, RouterModule } from '@angular/router';
 
 import { OverviewComponent } from './overview/overview.component';
 import { GettingStartedComponent } from './getting-started/getting-started.component';
+import { ChartComponent } from './chart/chart.component';
 import { ComponentsComponent } from './components.component';
 
 const routes: Routes = [
@@ -14,6 +15,9 @@ const routes: Routes = [
       }, {
         path: 'getting-started',
         component: GettingStartedComponent,
+      }, {
+        path: 'chart',
+        component: ChartComponent,
       }, {
         path: 'types',
         loadChildren: './types/types.module#TypesModule',

--- a/src/platform/echarts/base/README.md
+++ b/src/platform/echarts/base/README.md
@@ -1,0 +1,59 @@
+# td-chart
+
+`td-chart` element is the base component that instantiates an echarts object to facilitate its usage.
+
+## API Summary
+
+#### Inputs
+
++ config?: any
+  + Sets the JS config object if you choose to not use the property inputs.
+  + Note: property inputs override JS config conject properties.
++ themeName?: string
+  + theme to be applied into chart instance
++ renderer?: 'svg' | 'canvas'
+  + sets the rendering mode for the chart.
+  + defaults to 'canvas'
++ group?: string
+  + group name in which the chart instance will be connected to
+
+
+#### Outputs
+
++ chartClick
+  + event thrown when a chart element has been clicked.
++ chartDblclick
+  + event thrown when a chart element has been double clicked.
++ chartContextmenu
+  + event thrown when a chart element has been right-clicked.
+
+
+## Setup
+
+Import the [CovalentBaseEchartsModule] in your NgModule:
+
+```typescript
+import { CovalentBaseEchartsModule } from '@covalent/echarts/base';
+@NgModule({
+  imports: [
+    CovalentBaseEchartsModule,
+    ...
+  ],
+  ...
+})
+export class MyModule {}
+```
+
+## Usage
+
+```html
+<td-chart [style.height.px]="300"
+          [config]="{...}"
+          [themeName]="'light'"
+          [renderer]="'canvas'"
+          [group]="'group1'"
+          (chartClick)="doSomething()"
+          (chartDblclick)="doSomething()"
+          (chartContextmenu)="doSomething()">
+</td-chart>
+```

--- a/src/platform/echarts/base/base.module.ts
+++ b/src/platform/echarts/base/base.module.ts
@@ -11,6 +11,8 @@ export const BASE_MODULE_COMPONENTS: Type<any>[] = [
   TdChartYAxisComponent,
 ];
 
+import 'zrender/lib/svg/svg';
+
 @NgModule({
   imports: [
     CommonModule,


### PR DESCRIPTION
## Description
<!-- Talk about the great work you've done! -->

 add themeName and renderer inputs to set theme and render mode

Also add docs for td-chart's inputs and outputs

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `npm run serve`
- [ ] See chart docs 

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

closes https://github.com/Teradata/covalent-echarts/issues/43
