### PR TITLE
fix(config): change override order between inputs and config input

### DIFF
--- a/src/platform/echarts/bar/README.md
+++ b/src/platform/echarts/bar/README.md
@@ -8,7 +8,7 @@
 
 + config?: any
   + Sets the JS config object if you choose to not use the property inputs.
-  + Note: property inputs override JS config conject properties.
+  + Note: [config] input properties will override input values
 
 There are also lots of property inputs like:
 

--- a/src/platform/echarts/base/README.md
+++ b/src/platform/echarts/base/README.md
@@ -8,7 +8,7 @@
 
 + config?: any
   + Sets the JS config object if you choose to not use the property inputs.
-  + Note: property inputs override JS config conject properties.
+  + Note: [config] input properties will override input values
 + themeName?: string
   + theme to be applied into chart instance
 + renderer?: 'svg' | 'canvas'

--- a/src/platform/echarts/base/axis/README.md
+++ b/src/platform/echarts/base/axis/README.md
@@ -8,7 +8,7 @@
 
 + config?: any
   + Sets the JS config object if you choose to not use the property inputs.
-  + Note: property inputs override JS config conject properties.
+  + Note: [config] input properties will override input values
 
 There are also lots of property inputs like:
 

--- a/src/platform/echarts/base/axis/axis.component.ts
+++ b/src/platform/echarts/base/axis/axis.component.ts
@@ -84,7 +84,7 @@ export abstract class TdChartAxisComponent implements OnChanges, OnInit, OnDestr
   }
 
   private _setOptions(): void {
-    let config: any = assignDefined(this._state, this.config ? this.config : {}, {
+    let config: any = assignDefined(this._state, {
       id: this.id,
       show: this.show,
       gridIndex: this.gridIndex,
@@ -115,7 +115,7 @@ export abstract class TdChartAxisComponent implements OnChanges, OnInit, OnDestr
       axisPointer: this.axisPointer,
       zlevel: this.zlevel,
       z: this.z,
-    });
+    }, this.config ? this.config : {});
     this._optionsService.setArrayOption(this._axisOption, config);
   }
 

--- a/src/platform/echarts/base/chart.component.ts
+++ b/src/platform/echarts/base/chart.component.ts
@@ -123,7 +123,7 @@ export class TdChartComponent implements AfterViewInit, OnChanges, OnDestroy {
           containLabel: true,
           borderColor: '#FCFCFC',
         },
-      }, this.config ? this.config : {}, this._options), true);
+      }, this._options, this.config ? this.config : {}), true);
       this._changeDetectorRef.markForCheck();
     }
   }

--- a/src/platform/echarts/base/series/series.component.ts
+++ b/src/platform/echarts/base/series/series.component.ts
@@ -72,7 +72,7 @@ export abstract class TdSeriesComponent<T = any> implements ITdSeries<T>, OnChan
   abstract getConfig(): any;
 
   private _setOptions(): void {
-    let config: any = assignDefined(this._state, this.config ? this.config : {}, {
+    let config: any = assignDefined(this._state, {
       id: this.id,
       type: this.type,
       name: this.name,
@@ -87,7 +87,7 @@ export abstract class TdSeriesComponent<T = any> implements ITdSeries<T>, OnChan
       animationEasingUpdate: this.animationEasingUpdate,
       animationDelayUpdate: this.animationDelayUpdate,
       tooltip: this.tooltip,
-    } , this.getConfig(), this._options);
+    }, this.getConfig(), this._options, this.config ? this.config : {});
     this.optionsService.setArrayOption('series', config);
   }
 

--- a/src/platform/echarts/graph/README.md
+++ b/src/platform/echarts/graph/README.md
@@ -8,7 +8,7 @@
 
 + config?: any
   + Sets the JS config object if you choose to not use the property inputs.
-  + Note: property inputs override JS config conject properties.
+  + Note: [config] input properties will override input values
 
 There are also lots of property inputs like:
 

--- a/src/platform/echarts/line/README.md
+++ b/src/platform/echarts/line/README.md
@@ -8,7 +8,7 @@
 
 + config?: any
   + Sets the JS config object if you choose to not use the property inputs.
-  + Note: property inputs override JS config conject properties.
+  + Note: [config] input properties will override input values
 
 There are also lots of property inputs like:
 

--- a/src/platform/echarts/sankey/README.md
+++ b/src/platform/echarts/sankey/README.md
@@ -8,7 +8,7 @@
 
 + config?: any
   + Sets the JS config object if you choose to not use the property inputs.
-  + Note: property inputs override JS config conject properties.
+  + Note: [config] input properties will override input values
 
 There are also lots of property inputs like:
 

--- a/src/platform/echarts/scatter/README.md
+++ b/src/platform/echarts/scatter/README.md
@@ -8,7 +8,7 @@
 
 + config?: any
   + Sets the JS config object if you choose to not use the property inputs.
-  + Note: property inputs override JS config conject properties.
+  + Note: [config] input properties will override input values
 
 There are also lots of property inputs like:
 

--- a/src/platform/echarts/toolbox/README.md
+++ b/src/platform/echarts/toolbox/README.md
@@ -8,7 +8,7 @@
 
 + config?: any
   + Sets the JS config object if you choose to not use the property inputs.
-  + Note: property inputs override JS config conject properties.
+  + Note: [config] input properties will override input values
 
 There are also lots of property inputs like:
 

--- a/src/platform/echarts/tooltip/README.md
+++ b/src/platform/echarts/tooltip/README.md
@@ -8,7 +8,7 @@
 
 + config?: any
   + Sets the JS config object if you choose to not use the property inputs.
-  + Note: property inputs override JS config conject properties.
+  + Note: [config] input properties will override input values
 
 There are also lots of property inputs like:
 
@@ -30,7 +30,7 @@ And so many more.. for more info [click here](https://ecomfe.github.io/echarts-d
 
 + config?: any
   + Sets the JS config object if you choose to not use the property inputs.
-  + Note: property inputs override JS config conject properties.
+  + Note: [config] input properties will override input values
 
 There are also lots of property inputs like:
 

--- a/src/platform/echarts/tooltip/series-tooltip.component.ts
+++ b/src/platform/echarts/tooltip/series-tooltip.component.ts
@@ -57,7 +57,7 @@ export class TdSeriesTooltipComponent implements OnChanges, OnDestroy {
   }
 
   private _setOptions(): void {
-    let config: any = assignDefined(this._state, this.config ? this.config : {}, {
+    let config: any = assignDefined(this._state, {
       position: this.position,
       backgroundColor: this.backgroundColor,
       borderColor: this.borderColor,
@@ -66,7 +66,7 @@ export class TdSeriesTooltipComponent implements OnChanges, OnDestroy {
       textStyle: this.textStyle,
       extraCssText: this.extraCssText,
       formatter: this.formatter ? this.formatter : (this.formatterTemplate ? this._formatter() : undefined),
-    });
+    }, this.config ? this.config : {});
     // set series tooltip configuration in parent chart and render new configurations
     this._seriesComponent.setStateOption('tooltip', config);
   }

--- a/src/platform/echarts/tooltip/tooltip.component.ts
+++ b/src/platform/echarts/tooltip/tooltip.component.ts
@@ -84,7 +84,7 @@ export class TdChartTooltipComponent implements OnChanges, OnDestroy {
   }
 
   private _setOptions(): void {
-    let config: any = assignDefined(this._state, this.config ? this.config : {}, {
+    let config: any = assignDefined(this._state, {
       show: this.show,
       trigger: this.trigger,
       axisPointer: this.axisPointer,
@@ -104,7 +104,7 @@ export class TdChartTooltipComponent implements OnChanges, OnDestroy {
       padding: this.padding,
       textStyle: this.textStyle,
       extraCssText: this.extraCssText,
-    });
+    }, this.config ? this.config : {});
     // set tooltip configuration in parent chart and render new configurations
     this._optionsService.setOption('tooltip', config);
   }

--- a/src/platform/echarts/tree/README.md
+++ b/src/platform/echarts/tree/README.md
@@ -8,7 +8,7 @@
 
 + config?: any
   + Sets the JS config object if you choose to not use the property inputs.
-  + Note: property inputs override JS config conject properties.
+  + Note: [config] input properties will override input values
 
 There are also lots of property inputs like:
 

--- a/src/platform/echarts/treemap/README.md
+++ b/src/platform/echarts/treemap/README.md
@@ -8,7 +8,7 @@
 
 + config?: any
   + Sets the JS config object if you choose to not use the property inputs.
-  + Note: property inputs override JS config conject properties.
+  + Note: [config] input properties will override input values
 
 There are also lots of property inputs like:
 


### PR DESCRIPTION
## Description
<!-- Talk about the great work you've done! -->

This was a bad call on the overall design on which has a priority.. config input object will have to have a bigger priority than specific inputs since from a usage standpoint if you interact if the config object.. in means that you want a certain static behavior no matter what.

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `npm run serve`
- [ ] then this
- [ ] finally this

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

closes https://github.com/Teradata/covalent-echarts/issues/44