### PR TITLE
chore(): add npm audit into pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 dist: trusty
 
 node_js:
-- '8.9.4'
+- '10.15.3'
 branches:
   only:
     - master
@@ -20,6 +20,7 @@ jobs:
     - env: "MODE=aot"
     - env: "MODE=release"
     - env: "MODE=unit-test"
+    - env: "MODE=audit"
     - env: "MODE=a11y"
 install:
 - npm install

--- a/scripts/ci/travis-script.sh
+++ b/scripts/ci/travis-script.sh
@@ -39,6 +39,8 @@ elif [ "${MODE}" = "release" ]; then
   npm run build:lib
 elif [ "${MODE}" = "unit-test" ]; then
   npm run test
+elif [ "${MODE}" = "audit" ]; then
+  npm audit
 elif [ "${MODE}" = "a11y" ]; then
   npm run a11y
 fi


### PR DESCRIPTION
## Description
<!-- Talk about the great work you've done! -->

Adds `npm audit` in the travis pipeline to verify dependencies.

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.
